### PR TITLE
Allow default headers to be specified

### DIFF
--- a/lib/helpscout/client.rb
+++ b/lib/helpscout/client.rb
@@ -67,6 +67,13 @@ module HelpScout
       @@settings
     end
 
+    # Returns a hash resulting from the merge of call specific headers
+    # into default headers
+
+    def self.build_headers(headers)
+      headers = {} if headers.nil?
+      @@default_headers.merge(headers)
+    end
 
     # Requests a single item from the Help Scout API. Should return either an
     # item from the SingleItemEnvelope, or raise an error with an
@@ -94,7 +101,10 @@ module HelpScout
       end
 
       begin
-        response = Client.get(request_url, {:basic_auth => auth})
+        response = Client.get(request_url, {
+                                :basic_auth => auth,
+                                :headers => Client.build_headers({})
+                              })
       rescue SocketError => se
         raise StandardError, se.message
       end
@@ -150,7 +160,10 @@ module HelpScout
       end
 
       begin
-        response = Client.get(request_url, {:basic_auth => auth})
+        response = Client.get(request_url, {
+                                :basic_auth => auth,
+                                :headers => Client.build_headers({})
+                              })
       rescue SocketError => se
         raise StandardError, se.message
       end
@@ -204,7 +217,10 @@ module HelpScout
       end
 
       begin
-        response = Client.get(request_url, {:basic_auth => auth})
+        response = Client.get(request_url, {
+                                :basic_auth => auth,
+                                :headers => Client.build_headers({})
+                              })
       rescue SocketError => se
         raise StandardError, se.message
       end
@@ -237,7 +253,11 @@ module HelpScout
 
     def self.create_item(auth, url, params = {})
       begin
-        response = Client.post(url, {:basic_auth => auth, :headers => { 'Content-Type' => 'application/json' }, :body => params })
+        response = Client.post(url, {
+                                 :basic_auth => auth,
+                                 :headers => Client.build_headers({ 'Content-Type' => 'application/json' }),
+                                 :body => params
+                               })
       rescue SocketError => se
         raise StandardError, se.message
       end
@@ -268,7 +288,11 @@ module HelpScout
 
     def self.update_item(auth, url, params = {})
       begin
-        response = Client.put(url, {:basic_auth => auth, :headers => { 'Content-Type' => 'application/json' }, :body => params })
+        response = Client.put(url, {
+                                :basic_auth => auth,
+                                :headers => Client.build_headers({ 'Content-Type' => 'application/json' }),
+                                :body => params
+                              })
       rescue SocketError => se
         raise StandardError, se.message
       end
@@ -294,7 +318,10 @@ module HelpScout
 
     def self.post_request(auth, url)
       begin
-        response = Client.post(url, {:basic_auth => auth})
+        response = Client.post(url, {
+                                 :basic_auth => auth,
+                                 :headers => Client.build_headers({})
+                               })
       rescue SocketError => se
         raise StandardError, se.message
       end
@@ -322,7 +349,7 @@ module HelpScout
     # key  String  Help Scout API Key. Optional. If not passed, the key will be
     #              loaded from @@settings, which defaults to helpscout.yml.
 
-    def initialize(key=nil)
+    def initialize(key=nil, default_headers={})
       Client.settings
 
       if key.nil?
@@ -332,6 +359,9 @@ module HelpScout
       # The Help Scout API uses Basic Auth, where username is your API Key.
       # Password can be any arbitrary non-zero-length string.
       @auth = { :username => key, :password => "X" }
+
+      # Default headers that will be sent with all requests.
+      @@default_headers = default_headers || {}
     end
 
 

--- a/lib/helpscout/client.rb
+++ b/lib/helpscout/client.rb
@@ -46,6 +46,7 @@ module HelpScout
     base_uri 'https://api.helpscout.net/v1'
 
     @@settings ||= nil
+    @@default_headers ||= {}
 
     # Returns the current Help Scout Client settings.
     # If no settings have been loaded yet, this function will load its


### PR DESCRIPTION
# Problem
In order to be able to use Helpscout's v1 API after November 20, we'll need to send a special header with every request.

# Solution
This change allows the client to be instantiated with default headers that will be sent with every request. Example usage:
```
HelpScout::Client.new('authkey', {'V1-Extension' => 'OUR_SPECIAL_TOKEN'})
```

# Testing
_We should add specs to this lib if we plan on using this as the adapter for migrating to v2_

Spun up a simple http server that spits out http request data (headers, path, etc.). Used this to confirm that the client methods are still issuing http requests as expected with the addition of our new V1-Extension header. Example manual test and output:

## Test
```
c = HelpScout::Client.new('authkey', {'V1-Extension' => 'OUR_SPECIAL_TOKEN'})
c.run_workflow(1, 2)
```
## Output
```
----- Request Start ----->

/workflows/1/conversations/2.json
V1-Extension: OUR_SPECIAL_TOKEN
Authorization: Basic YXV0aGtleTpY
Connection: close
Host: localhost:8080
Content-Length: 0
Content-Type: application/x-www-form-urlencoded


<----- Request End -----

127.0.0.1 - - [15/Nov/2019 13:14:20] "POST /workflows/1/conversations/2.json HTTP/1.1" 200 -
```